### PR TITLE
fix(dataProcessPlots): Remove duplicate log-transformation of intensity

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,13 @@ Depends: R (>= 4.3)
 Imports: dplyr, gridExtra, stringr, stats, ggplot2, stringi,
             grDevices, MSstatsTMT, MSstatsConvert, MSstats,
             data.table, Rcpp, Biostrings, checkmate, ggrepel
-Suggests: knitr, rmarkdown, tinytest, covr
+Suggests: 
+    knitr,
+    rmarkdown,
+    tinytest,
+    covr,
+    mockery,
+    testthat (>= 3.0.0)
 LazyData: true
 LinkingTo: Rcpp
 VignetteBuilder: knitr
@@ -33,3 +39,4 @@ BugReports: https://github.com/Vitek-Lab/MSstatsPTM/issues
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.2
+Config/testthat/edition: 3

--- a/R/utils_dataProcessPlots.R
+++ b/R/utils_dataProcessPlots.R
@@ -89,9 +89,6 @@
   ## Adjust colnames to avoid repeating code
   for (i in seq_along(data.list)) {
     colnames(data.list[[i]]) = toupper(colnames(data.list[[i]]))
-    if ('INTENSITY' %in% colnames(data.list[[i]])){
-      data.list[[i]]$ABUNDANCE = log2(data.list[[i]]$INTENSITY)
-    }
     setnames(data.list[[i]], c('LOGINTENSITIES', 'GROUP', 'PROTEIN', 
                                'Protein', 'LOG2INTENSITY'), 
              c('ABUNDANCE', 'CONDITION', 'PROTEINNAME', 'PROTEINNAME',

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,13 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(mockery)
+library(MSstatsPTM)
+
+test_check("MSstatsPTM")

--- a/tests/testthat/test_dataProcessPlotsPTM.R
+++ b/tests/testthat/test_dataProcessPlotsPTM.R
@@ -1,0 +1,19 @@
+test_that("Medians are equalized in ptm data to QC plot helper function", {
+    mock_qc_all_plot_lf <- mock()
+    stub(
+        dataProcessPlotsPTM, ".qc.all.plot.lf",
+        mock_qc_all_plot_lf, depth=2
+    )
+    
+    dataProcessPlotsPTM(summary.data,
+                        type = 'QCPLOT',
+                        which.PTM = "allonly",
+                        address = FALSE)
+    
+    calls <- mock_args(mock_qc_all_plot_lf)
+    ptm_data <- calls[[1]][[1]]
+    run_data = split(ptm_data, ptm_data$RUN)
+    for (i in 1:length(run_data)){
+        expect_equal(median(run_data[[i]]$ABUNDANCE, na.rm = TRUE), 22.028431)
+    }
+})


### PR DESCRIPTION
# Motivation and Context

In this google group [post](https://groups.google.com/g/msstats/c/da_WneFMd4A/m/0ArHn3-TAQAJ), the user pointed out that medians were not equalized in the QC plot.  After investigating, it looks to be a bug in the dataProcessPlots function.

## Changes

- Remove code that log transforms the intensity into the abundance column in dataProcessPlots.  This code essentially log transforms the data and removes all normalization applied earlier.  

## Testing

- Generated new plots with `summary.data` object and medians are equalized now.
- Added unit test that verified abundance data was not manipulated - i.e. medians are all equal

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules