### PR TITLE
docs(vignette): Add additional information on the importance of a FASTA file

### DIFF
--- a/vignettes/MSstatsPTM_LabelFree_Workflow.Rmd
+++ b/vignettes/MSstatsPTM_LabelFree_Workflow.Rmd
@@ -57,6 +57,19 @@ for your tool in `MSstatsPTM`, you can alternatively leverage converters from
 base `MSstats`. If using converters from `MSstats` note they will need to be 
 run both on the global protein and PTM datasets.
 
+You might notice a FASTA file is also needed for some converters. This
+FASTA file can be obtained by querying
+[Uniprot](https://www.uniprot.org/id-mapping) with all of the protein
+IDs present in your PTM dataset. The FASTA file is a necessary input
+because some tools (e.g. MaxQuant) do not report the specific amino acid
+that is modified relative to the whole *protein* sequence. Rather, they
+report the specific amino acid relative to the reported *peptide*. This
+distinction is important because modifications like phosphorylation,
+methylation, or acetylation often have specific roles depending on where
+they occur within the full-length protein. With the help of a FASTA
+file, MSstatsPTM can determine the specific amino acid that is modified
+in the context of the whole protein sequence.
+
 Please note for the PTM dataset, both the protein and modification site (or 
 peptide), must be added into the `ProteinName` column. This allows for the 
 package to summarize to the peptide level, and avoid the off chance there are 


### PR DESCRIPTION
# Motivation and Context

One [user](https://groups.google.com/g/msstats/c/BULEJ6D2hVA) had a lot of trouble realizing how the FASTA file worked, even with the vignette.  Upon first inspection, our vignettes do not mention anything about the importance of a FASTA file.  

## Changes

- Added a paragraph describing how to get the FASTA file from Uniprot and why it's important in the MSstatsPTM vignette

## Testing

- Vignette builds fine.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules