### PR TITLE
tests(dataProcessPlotsPTM): Fix unit tests in dataProcessPlotsPTM

### DIFF
--- a/tests/testthat/test_dataProcessPlotsPTM.R
+++ b/tests/testthat/test_dataProcessPlotsPTM.R
@@ -1,15 +1,15 @@
+library(grid)
+
 test_that("Medians are equalized in ptm data to QC plot helper function", {
-    mock_qc_all_plot_lf <- mock()
+    mock_qc_all_plot_lf <- mock(rectGrob(), cycle = TRUE)
     stub(
         dataProcessPlotsPTM, ".qc.all.plot.lf",
         mock_qc_all_plot_lf, depth=2
     )
-    
     dataProcessPlotsPTM(summary.data,
                         type = 'QCPLOT',
                         which.PTM = "allonly",
                         address = FALSE)
-    
     calls <- mock_args(mock_qc_all_plot_lf)
     ptm_data <- calls[[1]][[1]]
     run_data = split(ptm_data, ptm_data$RUN)


### PR DESCRIPTION
# Motivation and Context

There's a unit test failing in [bioconductor](https://bioconductor.org/checkResults/release/bioc-LATEST/MSstatsPTM/lconway-checksrc.html).  It's because the mock doesn't return a grob object which is needed for the `grid.arrange` function later.

## Changes
- Pass a grob object as a return object in the mock for `.qc.all.plot.lf`

## Testing

- Tests all pass now

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules