### PR TITLE
chore(groupComparisonPTM): Fix bugs and unit tests

### DIFF
--- a/R/converters.R
+++ b/R/converters.R
@@ -520,6 +520,12 @@ MaxQtoMSstatsPTMFormat = function(evidence=NULL,
     .checkAnnotation(annotation_protein, labeling_type)
   }
   
+  if (!is.null(evidence_prot)){
+    if (is.null(proteinGroups)) {
+      stop("proteinGroups is NULL.  Please input the proteinGroups file from your global proteome dataset using the proteinGroups parameter")
+    }
+  }
+  
   # .checkMaxQconverterParams(mod.num,
   #                           ptm.keyword,
   #                           which.proteinid.ptm,
@@ -625,11 +631,6 @@ MaxQtoMSstatsPTMFormat = function(evidence=NULL,
   
   if (!is.null(evidence_prot)){
     annotation_protein = as.data.table(annotation_protein)
-    
-    ## Clean raw data
-    #evidence = as.data.table(evidence)
-    # evidence = evidence[!grepl("phos", evidence$Raw.file),]
-    #proteinGroups = as.data.table(proteinGroups)
     
     if(labeling_type == "TMT"){
       msstats.abun = MaxQtoMSstatsTMTFormat(evidence = evidence_prot,

--- a/R/designSampleSizePTM.R
+++ b/R/designSampleSizePTM.R
@@ -47,7 +47,8 @@
 #' 
 #' @examples
 #' model.lf.msstatsptm = groupComparisonPTM(summary.data, 
-#'                                      data.type = "LabelFree",
+#'                                      ptm_label_type="LF",
+#'                                      protein_label_type="LF",
 #'                                      verbose = FALSE)
 #'                                      
 #' #(1) Minimal number of biological replicates per condition

--- a/R/groupComparisonPTM.R
+++ b/R/groupComparisonPTM.R
@@ -105,7 +105,13 @@ groupComparisonPTM = function(data,
   ## Create pairwise matrix for label free
   if (contrast.matrix[1] == "pairwise"){
     # getOption(option_log)("INFO", "Building pairwise matrix.")
-    labels = unique(data.ptm$ProteinLevelData$GROUP)
+    if ("GROUP" %in% colnames(data.ptm$ProteinLevelData)) {
+      labels <- unique(data.ptm$ProteinLevelData$GROUP)
+    } else if ("Condition" %in% colnames(data.ptm$ProteinLevelData)) {
+      labels <- unique(data.ptm$ProteinLevelData$Condition)
+    } else {
+      stop("Error: Neither 'GROUP' nor 'Condition' column exists in data.ptm$ProteinLevelData.")
+    }
     contrast.matrix = MSstatsContrastMatrix('pairwise', labels)
   }
   

--- a/R/groupComparisonPlotsPTM.R
+++ b/R/groupComparisonPlotsPTM.R
@@ -84,7 +84,8 @@
 #' @examples 
 #' 
 #' model.lf.msstatsptm = groupComparisonPTM(summary.data, 
-#'                                      data.type = "LabelFree")
+#'                                      ptm_label_type="LF",
+#'                                      protein_label_type="LF")
 #' groupComparisonPlotsPTM(data = model.lf.msstatsptm,
 #'                         type = "VolcanoPlot",
 #'                         FCcutoff= 2,

--- a/inst/tinytest/test_groupComparisonPTM.R
+++ b/inst/tinytest/test_groupComparisonPTM.R
@@ -6,15 +6,18 @@ data("summary.data.tmt", package = "MSstatsPTM")
 expect_error(groupComparisonPTM())
 expect_error(groupComparisonPTM(list(PTM = NULL, 
                                      PROTEIN = summary.data$PROTEIN), 
-                                data.type = "LabelFree"))
+                                ptm_label_type="LF",
+                                protein_label_type="LF"))
 
 expect_silent(groupComparisonPTM(list(PTM = summary.data$PTM, 
                                      PROTEIN = NULL), 
-                                data.type = "LabelFree"))
+                                 ptm_label_type="LF",
+                                 protein_label_type="LF"))
 
 ## Test expected output - LF
 group.comp <- MSstatsPTM::groupComparisonPTM(summary.data, 
-                                             data.type = "LabelFree")
+                                             ptm_label_type="LF",
+                                             protein_label_type="LF")
 expect_inherits(group.comp, "list")
 expect_inherits(group.comp$PTM.Model, "data.table")
 expect_inherits(group.comp$PROTEIN.Model, "data.table")
@@ -34,7 +37,8 @@ expect_equal(colnames(group.comp$ADJUSTED.Model),
 
 ## Test expected output - TMT
 group.comp.tmt <- MSstatsPTM::groupComparisonPTM(summary.data.tmt, 
-                                                 data.type = "TMT")
+                                                 ptm_label_type="TMT",
+                                                 protein_label_type="TMT")
 expect_inherits(group.comp.tmt, "list")
 expect_inherits(group.comp.tmt$PTM.Model, "data.table")
 expect_inherits(group.comp.tmt$PROTEIN.Model, "data.table")

--- a/man/dataProcessPTM.Rd
+++ b/man/dataProcessPTM.Rd
@@ -10,6 +10,10 @@ dataProcessPTM(
   protein_label_type,
   MBimpute_ptm = FALSE,
   MBimpute_protein = TRUE,
+  use_log_file = TRUE,
+  append = FALSE,
+  verbose = TRUE,
+  log_file_path = NULL,
   ...
 )
 }

--- a/man/designSampleSizePTM.Rd
+++ b/man/designSampleSizePTM.Rd
@@ -72,7 +72,8 @@ calculation (numSample, numPep, numTran, power) at the same time.
 }
 \examples{
 model.lf.msstatsptm = groupComparisonPTM(summary.data, 
-                                     data.type = "LabelFree",
+                                     ptm_label_type="LF",
+                                     protein_label_type="LF",
                                      verbose = FALSE)
                                      
 #(1) Minimal number of biological replicates per condition

--- a/man/groupComparisonPlotsPTM.Rd
+++ b/man/groupComparisonPlotsPTM.Rd
@@ -132,7 +132,8 @@ between conditions and peptides/proteins
 \examples{
 
 model.lf.msstatsptm = groupComparisonPTM(summary.data, 
-                                     data.type = "LabelFree")
+                                     ptm_label_type="LF",
+                                     protein_label_type="LF")
 groupComparisonPlotsPTM(data = model.lf.msstatsptm,
                         type = "VolcanoPlot",
                         FCcutoff= 2,

--- a/vignettes/MSstatsPTM_LabelFree_Workflow.Rmd
+++ b/vignettes/MSstatsPTM_LabelFree_Workflow.Rmd
@@ -335,7 +335,8 @@ row.names(comparison) = "CCCP-Ctrl"
 colnames(comparison) = c("CCCP", "Combo", "Ctrl", "USP30_OE")
 
 MSstatsPTM.model = groupComparisonPTM(MSstatsPTM.summary, 
-                                      data.type = "LabelFree",
+                                      ptm_label_type = "LF",
+                                      protein_label_type = "LF",
                                       contrast.matrix = comparison,
                                       use_log_file = FALSE, append = FALSE,
                                       verbose = FALSE)

--- a/vignettes/MSstatsPTM_TMT_Workflow.Rmd
+++ b/vignettes/MSstatsPTM_TMT_Workflow.Rmd
@@ -125,7 +125,8 @@ row.names(comparison)<-c('1-4', '2-5', '3-6', '1-3',
 colnames(comparison) <- c('Condition_1','Condition_2','Condition_3',
                           'Condition_4','Condition_5','Condition_6')
 MSstatsPTM.model <- groupComparisonPTM(MSstatsPTM.summary,
-                                       data.type = "TMT",
+                                       ptm_label_type = "TMT",
+                                       protein_label_type = "TMT",
                                        contrast.matrix = comparison,
                                        use_log_file = FALSE, append = FALSE)
 head(MSstatsPTM.model$PTM.Model)


### PR DESCRIPTION
# Motivation and Context
## Problem 1
This [commit](https://github.com/Vitek-Lab/MSstatsPTM/commit/004833a315170c147fdca95cb505decf8bddcfe0) is causing build failures.  

## Problem 2
User was having issues because `proteinGroups` was NULL when including a global proteome dataset.  User should get an error about this field being null.  Right now, the error is:

```
Error in data.table::fread(input, showProgress = FALSE, ...) : 
  input= must be a single character string containing a file name, a system command containing at least one space, a URL starting 'http[s]://', 'ftp[s]://' or 'file://', or, the input data itself containing at least one \n or \r
```

## Changes
- Fix changes related to groupComparisonPTM in code and tests
- Add error message early on that validates that the proteinGroups file is not null

## Testing

Dry run passes

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules