### PR TITLE
Add data.type parameter back to groupComparisonPTM for backwards compatibility

### DIFF
--- a/R/groupComparisonPTM.R
+++ b/R/groupComparisonPTM.R
@@ -21,10 +21,6 @@
 #' type.
 #' @param data.type Type of data. Must be one of `LF` or `TMT`. Will be deprecated 
 #' in favor of ptm_label_type and protein_label_type.
-#' @param ptm_label_type Indicator of labeling type for PTM dataset. Must be one
-#' of `LF` or `TMT`
-#' @param protein_label_type Indicator of labeling type for PROTEIN dataset. 
-#' Must be one of `LF` or `TMT`
 #' @param contrast.matrix comparison between conditions of interests. Default 
 #' models full pairwise comparison between all conditions
 #' @param moderated For TMT experiments only. TRUE will moderate t statistic; 
@@ -46,6 +42,10 @@
 #' If not provided, such a file will be created automatically.
 #' If `append = TRUE`, has to be a valid path to a file.
 #' @param base start of the file name.
+#' @param ptm_label_type Indicator of labeling type for PTM dataset. Must be one
+#' of `LF` or `TMT`
+#' @param protein_label_type Indicator of labeling type for PROTEIN dataset. 
+#' Must be one of `LF` or `TMT`
 #' @return list of modeling results. Includes PTM, PROTEIN, and ADJUSTED
 #'         data.tables with their corresponding model results.
 #'         
@@ -57,8 +57,6 @@
 #'                                      verbose = FALSE)
 groupComparisonPTM = function(data, 
                               data.type = NULL,
-                              ptm_label_type = "LF",
-                              protein_label_type = "LF",
                               contrast.matrix = "pairwise",
                               moderated = FALSE, 
                               adj.method = "BH",
@@ -68,7 +66,9 @@ groupComparisonPTM = function(data,
                               append = FALSE,
                               verbose = TRUE, 
                               log_file_path = NULL,
-                              base = "MSstatsPTM_log_") {
+                              base = "MSstatsPTM_log_",
+                              ptm_label_type = "LF",
+                              protein_label_type = "LF") {
   
   ## Start log  
   # if (is.null(log_file_path) & use_log_file == TRUE){

--- a/R/groupComparisonPTM.R
+++ b/R/groupComparisonPTM.R
@@ -19,6 +19,8 @@
 #' function \code{\link[MSstatsPTM]{dataSummarizationPTM}}  or 
 #' \code{\link[MSstatsPTM]{dataSummarizationPTM_TMT}} depending on acquisition
 #' type.
+#' @param data.type Type of data. Must be one of `LF` or `TMT`. Will be deprecated 
+#' in favor of ptm_label_type and protein_label_type.
 #' @param ptm_label_type Indicator of labeling type for PTM dataset. Must be one
 #' of `LF` or `TMT`
 #' @param protein_label_type Indicator of labeling type for PROTEIN dataset. 
@@ -54,8 +56,9 @@
 #'                                      protein_label_type="LF",
 #'                                      verbose = FALSE)
 groupComparisonPTM = function(data, 
-                              ptm_label_type,
-                              protein_label_type,
+                              data.type = NULL,
+                              ptm_label_type = "LF",
+                              protein_label_type = "LF",
                               contrast.matrix = "pairwise",
                               moderated = FALSE, 
                               adj.method = "BH",
@@ -88,6 +91,10 @@ groupComparisonPTM = function(data,
   #                     pkg_name = pkg)
   
   # getOption(option_log)("INFO", "Starting parameter and data checks..")
+  if (!is.null(data.type) && (data.type == "TMT" || data.type == "LF")) {
+      ptm_label_type = data.type
+      protein_label_type = data.type
+  }
   
   Label = Site = NULL
   
@@ -234,6 +241,12 @@ groupComparisonPTM = function(data,
                   'ADJUSTED.Model'=adjusted_models, 
                   'Model.Details'=list('PTM'=ptm_model_details,
                                        'PROTEIN'=protein_model_details))
+  }
+  
+  if (!is.null(data.type) && (data.type == "TMT" || data.type == "LF")) {
+      warning("DEPRECATION NOTICE: The `data.type` argument is being deprecated. 
+              Please use `ptm_label_type` and `protein_label_type` instead ahead
+              of Release 3.22")
   }
 
   return(models)

--- a/man/groupComparisonPTM.Rd
+++ b/man/groupComparisonPTM.Rd
@@ -6,8 +6,9 @@
 \usage{
 groupComparisonPTM(
   data,
-  ptm_label_type,
-  protein_label_type,
+  data.type = NULL,
+  ptm_label_type = "LF",
+  protein_label_type = "LF",
   contrast.matrix = "pairwise",
   moderated = FALSE,
   adj.method = "BH",
@@ -25,6 +26,9 @@ groupComparisonPTM(
 function \code{\link[MSstatsPTM]{dataSummarizationPTM}}  or
 \code{\link[MSstatsPTM]{dataSummarizationPTM_TMT}} depending on acquisition
 type.}
+
+\item{data.type}{Type of data. Must be one of \code{LF} or \code{TMT}. Will be deprecated
+in favor of ptm_label_type and protein_label_type.}
 
 \item{ptm_label_type}{Indicator of labeling type for PTM dataset. Must be one
 of \code{LF} or \code{TMT}}


### PR DESCRIPTION
# Motivation and Context

We accidentally deprecated the data.type parameter, but that will cause existing automated workflows for break.  For backwards compatibility, we'll first have a warning message, and then introduce an error message later on in release 3.22.

## Changes
- Reintroduce back the data.type parameter such that it is assigned to ptm_label_type and protein_label_type temporarily.

## Testing

Verified locally there are no issues.

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules