### PR TITLE
fix(maxQuant): Remove unmodified peptides from PTM dataset

### DIFF
--- a/R/converters.R
+++ b/R/converters.R
@@ -640,8 +640,6 @@ MaxQtoMSstatsPTMFormat = function(evidence=NULL,
                                                            keep = 1)]
   }
   
-  MSstatsPTMformat = list('PTM' = msstatsptm_input)
-  
   if (!is.null(evidence_prot)){
     annotation_protein = as.data.table(annotation_protein)
     
@@ -659,7 +657,7 @@ MaxQtoMSstatsPTMFormat = function(evidence=NULL,
     
     MSstatsPTMformat = list('PTM' = msstatsptm_input, 
                             "PROTEIN" = msstats.abun)
-    
+    return(MSstatsPTMformat)
   }
   
   if (use_unmod_peptides){
@@ -668,6 +666,9 @@ MaxQtoMSstatsPTMFormat = function(evidence=NULL,
     
     MSstatsPTMformat = list(PTM = msstatsptm_input, 
                             PROTEIN = msstats.abun)
+  } else {
+    msstatsptm_input = msstatsptm_input[grepl(mod_id, msstatsptm_input$PeptideSequence),]
+    MSstatsPTMformat = list('PTM' = msstatsptm_input)
   }
   
   return(MSstatsPTMformat)

--- a/R/converters.R
+++ b/R/converters.R
@@ -655,6 +655,7 @@ MaxQtoMSstatsPTMFormat = function(evidence=NULL,
                                          proteinID = which_proteinid_protein)
     }
     
+    msstatsptm_input = msstatsptm_input[grepl(mod_id, msstatsptm_input$PeptideSequence),]
     MSstatsPTMformat = list('PTM' = msstatsptm_input, 
                             "PROTEIN" = msstats.abun)
     return(MSstatsPTMformat)

--- a/inst/tinytest/test_converters.R
+++ b/inst/tinytest/test_converters.R
@@ -5,9 +5,13 @@
 #' @author Anthony Wu
 #' 
 #' @param msstats_ptm_input A list containing PTM and PROTEIN data tables
-.validatePositiveNumberOfRows = function(msstats_ptm_input) {
+.validatePositiveNumberOfRows = function(msstats_ptm_input, global_profiling = TRUE) {
     expect_true(nrow(msstats_ptm_input$PTM) > 0)
-    expect_true(nrow(msstats_ptm_input$PROTEIN) > 0)
+    if (global_profiling) {
+      expect_true(nrow(msstats_ptm_input$PROTEIN) > 0) 
+    } else {
+      expect_true(is.null(msstats_ptm_input$PROTEIN))
+    }
 }
 
 #' Validate protein ID count in converter output
@@ -35,7 +39,7 @@
     )
 }
 
-## MaxQ TMT
+## MaxQ TMT useUnmodPeptides = TRUE
 data("maxq_tmt_evidence", package = "MSstatsPTM")
 data("maxq_tmt_annotation", package = "MSstatsPTM")
 
@@ -84,12 +88,26 @@ mq_imported = MaxQtoMSstatsPTMFormat(evidence=maxq_tmt_evidence,
 .validateProteinId(mq_imported$PTM, "P29966_T150", 70)
 .validateProteinId(mq_imported$PTM, "P29966_T143_S145", 10)
 .validatePtmSubstring(
-    mq_imported$PTM, "Phospho \\(STY\\)", 
-    length(mq_imported$PTM$PeptideSequence))
+  mq_imported$PTM, "Phospho \\(STY\\)", 
+  length(mq_imported$PTM$PeptideSequence))
 .validatePtmSubstring(
-    mq_imported$PROTEIN, "Phospho \\(STY\\)", 0)
+  mq_imported$PROTEIN, "Phospho \\(STY\\)", 0)
 
-## MaxQ LF
+## MaxQ TMT useUnmodPeptides = FALSE
+mq_imported = MaxQtoMSstatsPTMFormat(evidence=maxq_tmt_evidence,
+                                     annotation=maxq_tmt_annotation,
+                                     fasta=system.file("extdata", "maxq_tmt_fasta.fasta", package="MSstatsPTM"),
+                                     fasta_protein_name="uniprot_ac",
+                                     use_unmod_peptides=FALSE,
+                                     labeling_type = "TMT")
+.validatePositiveNumberOfRows(mq_imported, global_profiling = FALSE)
+.validateProteinId(mq_imported$PTM, "P29966_T150", 70)
+.validateProteinId(mq_imported$PTM, "P29966_T143_S145", 10)
+.validatePtmSubstring(
+  mq_imported$PTM, "Phospho \\(STY\\)", 
+  length(mq_imported$PTM$PeptideSequence))
+
+## MaxQ LF useUnmodPeptides = TRUE
 data("maxq_lf_evidence", package = "MSstatsPTM")
 data("maxq_lf_annotation", package = "MSstatsPTM")
 
@@ -154,6 +172,22 @@ mq_imported = MaxQtoMSstatsPTMFormat(evidence=maxq_lf_evidence,
     length(mq_imported$PTM$PeptideSequence))
 .validatePtmSubstring(
     mq_imported$PROTEIN, "Phospho \\(STY\\)", 0)
+
+## MaxQ LF useUnmodPeptides = FALSE
+mq_imported = MaxQtoMSstatsPTMFormat(evidence=maxq_lf_evidence,
+                                     annotation=maxq_lf_annotation,
+                                     fasta=system.file("extdata", "maxq_lf_fasta.fasta", package="MSstatsPTM"),
+                                     fasta_protein_name="uniprot_ac",
+                                     mod_id="\\(Phospho \\(STY\\)\\)",
+                                     use_unmod_peptides=FALSE,
+                                     labeling_type = "LF",
+                                     which_proteinid_ptm = "Proteins")
+.validatePositiveNumberOfRows(mq_imported, global_profiling = FALSE)
+.validateProteinId(mq_imported$PTM, "P36578_S295", 66)
+.validateProteinId(mq_imported$PTM, "Q13523_S431_S437", 33)
+.validatePtmSubstring(
+  mq_imported$PTM, "Phospho \\(STY\\)", 
+  length(mq_imported$PTM$PeptideSequence))
 
 ## Spectronaut
 data("spectronaut_input", package = "MSstatsPTM")

--- a/inst/tinytest/test_converters.R
+++ b/inst/tinytest/test_converters.R
@@ -5,6 +5,8 @@
 #' @author Anthony Wu
 #' 
 #' @param msstats_ptm_input A list containing PTM and PROTEIN data tables
+#' @param global_profiling Default TRUE indicates msstats_ptm_input should have 
+#' the PROTEIN element
 .validatePositiveNumberOfRows = function(msstats_ptm_input, global_profiling = TRUE) {
     expect_true(nrow(msstats_ptm_input$PTM) > 0)
     if (global_profiling) {


### PR DESCRIPTION
# Motivation and Context

Unmodified peptides were showing up in the PTM dataset after conversion for MaxQuant.  We should filter out these peptides since they add additional hypotheses to test that are not necessary to test. 

## Changes

- Filter out unmodified peptides from the PTM dataset.  

## Testing

- Verified with a test dataset
- Added unit tests when setting useUnmodPeptides to False

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PTM and protein data to ensure only peptides with the specified modification are included when unmodified peptides are excluded.
  * Enhanced processing to return results more efficiently when additional protein evidence is provided.
* **Tests**
  * Added new test cases validating data conversion without unmodified peptides, ensuring accurate filtering and data integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->