### PR TITLE
fix(annotation): Enable fractions in label free experiments

### DIFF
--- a/R/utils_checks.R
+++ b/R/utils_checks.R
@@ -11,7 +11,7 @@
   
   if (label_type == "LF"){
     max_columns = c("Run", "Raw.file", "Condition", 
-                    "BioReplicate", "IsotopeLabelType")
+                    "BioReplicate", "IsotopeLabelType", "Fraction")
   } else if (label_type == "TMT"){
     max_columns = c("Run", "Raw.file", "Fraction", "TechRepMixture", "Channel", 
                     "Condition", "Mixture", "BioReplicate")

--- a/R/utils_checks.R
+++ b/R/utils_checks.R
@@ -15,6 +15,9 @@
   } else if (label_type == "TMT"){
     max_columns = c("Run", "Raw.file", "Fraction", "TechRepMixture", "Channel", 
                     "Condition", "Mixture", "BioReplicate")
+  } else {
+    msg = paste("Labeling type must be either LF or TMT")
+    stop(msg)
   }
   
   if (sum(columns %in% max_columns) != length(columns)){

--- a/inst/tinytest/test_utils_checks.R
+++ b/inst/tinytest/test_utils_checks.R
@@ -1,0 +1,161 @@
+# MSstatsPTM:::.checkAnnotation tests
+## Test missing Run/Raw.file columns
+annotation_no_run <- data.frame(
+    Condition = c("A", "B"),
+    BioReplicate = c(1, 2)
+)
+
+expect_error(
+    MSstatsPTM:::.checkAnnotation(annotation_no_run, "LF"),
+    pattern = "Run column missing in annotation file"
+)
+
+expect_error(
+    MSstatsPTM:::.checkAnnotation(annotation_no_run, "TMT"),
+    pattern = "Run column missing in annotation file"
+)
+
+## Test valid Run column
+annotation_with_run <- data.frame(
+    Run = c("run1", "run2"),
+    Condition = c("A", "B")
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_with_run, "LF"))
+
+## Test valid Raw.file column
+annotation_with_rawfile <- data.frame(
+    Raw.file = c("file1.raw", "file2.raw"),
+    Condition = c("A", "B")
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_with_rawfile, "LF"))
+
+## Test both Run and Raw.file columns
+annotation_with_both <- data.frame(
+    Run = c("run1", "run2"),
+    Raw.file = c("file1.raw", "file2.raw"),
+    Condition = c("A", "B")
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_with_both, "LF"))
+
+## Test LF label_type with all valid columns
+annotation_lf_valid <- data.frame(
+    Run = c("run1", "run2"),
+    Raw.file = c("file1.raw", "file2.raw"),
+    Condition = c("A", "B"),
+    BioReplicate = c(1, 2),
+    IsotopeLabelType = c("L", "H"),
+    Fraction = c(1, 1)
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_lf_valid, "LF"))
+
+## Test LF label_type with subset of valid columns
+annotation_lf_subset <- data.frame(
+    Run = c("run1", "run2"),
+    Condition = c("A", "B"),
+    BioReplicate = c(1, 2)
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_lf_subset, "LF"))
+
+## Test TMT label_type with all valid columns
+annotation_tmt_valid <- data.frame(
+    Run = c("run1", "run2"),
+    Raw.file = c("file1.raw", "file2.raw"),
+    Fraction = c(1, 1),
+    TechRepMixture = c(1, 1),
+    Channel = c("126", "127"),
+    Condition = c("A", "B"),
+    Mixture = c(1, 1),
+    BioReplicate = c(1, 2)
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_tmt_valid, "TMT"))
+
+## Test TMT label_type with subset of valid columns
+annotation_tmt_subset <- data.frame(
+    Run = c("run1", "run2"),
+    Channel = c("126", "127"),
+    Condition = c("A", "B")
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_tmt_subset, "TMT"))
+
+## Test extra columns for LF
+annotation_lf_extra <- data.frame(
+    Run = c("run1", "run2"),
+    Condition = c("A", "B"),
+    ExtraColumn = c("extra1", "extra2")  # This should not be allowed
+)
+
+expect_error(
+    MSstatsPTM:::.checkAnnotation(annotation_lf_extra, "LF"),
+    pattern = "Extra columns included in the annotation file"
+)
+
+## Test that error message contains allowed columns for LF
+expect_error(
+    MSstatsPTM:::.checkAnnotation(annotation_lf_extra, "LF"),
+    pattern = "Run, Raw.file, Condition, BioReplicate, IsotopeLabelType, Fraction"
+)
+
+## Test extra columns for TMT
+annotation_tmt_extra <- data.frame(
+    Run = c("run1", "run2"),
+    Channel = c("126", "127"),
+    Condition = c("A", "B"),
+    InvalidColumn = c("invalid1", "invalid2")  # This should not be allowed
+)
+
+expect_error(
+    MSstatsPTM:::.checkAnnotation(annotation_tmt_extra, "TMT"),
+    pattern = "Extra columns included in the annotation file"
+)
+
+## Test that error message contains allowed columns for TMT
+expect_error(
+    MSstatsPTM:::.checkAnnotation(annotation_tmt_extra, "TMT"),
+    pattern = "Run, Raw.file, Fraction, TechRepMixture, Channel, Condition, Mixture, BioReplicate"
+)
+
+## Test empty data frame
+annotation_empty <- data.frame()
+
+expect_error(
+    MSstatsPTM:::.checkAnnotation(annotation_empty, "LF"),
+    pattern = "Run column missing in annotation file"
+)
+
+## Test only Run column
+annotation_only_run <- data.frame(
+    Run = c("run1", "run2")
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_only_run, "LF"))
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_only_run, "TMT"))
+
+## Test only Raw.file column
+annotation_only_rawfile <- data.frame(
+    Raw.file = c("file1.raw", "file2.raw")
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_only_rawfile, "LF"))
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_only_rawfile, "TMT"))
+
+## Test different label_type values
+annotation_basic <- data.frame(
+    Run = c("run1", "run2"),
+    Condition = c("A", "B")
+)
+
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_basic, "LF"))
+expect_silent(MSstatsPTM:::.checkAnnotation(annotation_basic, "TMT"))
+
+## Test unknown label_type
+expect_error(
+    MSstatsPTM:::.checkAnnotation(annotation_basic, "UNKNOWN"),
+    pattern = "Labeling type must be either LF or TMT"
+)


### PR DESCRIPTION
# Motivation and Context

we need to enable fractionation experiments with MSstatsPTM with label free https://groups.google.com/g/msstats/c/G9US-6V8uyM

## Testing

- Added unit tests

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - LF annotations now accept the Fraction column.
- Bug Fixes
  - Added clear validation for unsupported labeling types, returning “Labeling type must be either LF or TMT” and stopping early to prevent downstream errors.
  - Improved robustness of annotation checks for LF and TMT, reducing false errors on valid inputs.
- Tests
  - Introduced comprehensive tests covering LF/TMT annotation validation, including missing/extra columns, empty inputs, valid minimal schemas, and error message accuracy, ensuring reliable behavior across common scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->