### PR TITLE
fix(dataProcessPlotsPTM, groupComparisonPlotsPTM): Migrate away from deprecated functions for ggplot

### DIFF
--- a/R/utils_dataProcessPlots.R
+++ b/R/utils_dataProcessPlots.R
@@ -298,7 +298,7 @@
                          data = sub) +
     facet_grid(~RUN) +
     geom_point(data = sub, aes(shape=.data$CENSORED), size=dot.size.profile, na.rm=TRUE) +
-    geom_line(size = 0.5, na.rm=TRUE) +
+    geom_line(linewidth = 0.5, na.rm=TRUE) +
     scale_colour_manual(values=cbp[s]) +
     scale_linetype_manual(values = ss) +
     scale_shape_manual(values = c(16, 1),labels = c("Detected data", "Censored missing data")) +
@@ -424,7 +424,7 @@
     facet_grid(~RUN) +
     # geom_point(size = dot.size.profile, na.rm=TRUE) +
     geom_point(data = final, aes(shape=.data$CENSORED), size=dot.size.profile, na.rm=TRUE) +
-    geom_line(size = 0.5, na.rm=TRUE) +
+    geom_line(linewidth = 0.5, na.rm=TRUE) +
     scale_colour_manual(values = c("lightgray", "darkred")) +
     scale_shape_manual(values = c(16, 1),labels = c("Detected data", "Censored missing data")) +
     scale_size_manual(values = c(1.7, 2), guide = "none") +
@@ -1146,7 +1146,7 @@
                size=dot.size.profile, na.rm=TRUE) +
     geom_line(aes(x=.data$RUN, y=.data$ABUNDANCE, 
                          color=.data$FEATURE, linetype=.data$FEATURE), #
-              size = 0.5, na.rm=TRUE) +
+              linewidth = 0.5, na.rm=TRUE) +
     scale_colour_manual(values=cbp[s]) +
     scale_linetype_manual(values = ss) +
     scale_shape_manual(values = c(16, 1),labels = c("Detected data", "Censored missing data")) +
@@ -1250,7 +1250,7 @@
     geom_point(aes(x=.data$RUN, y=.data$ABUNDANCE, 
                           color=.data$analysis, shape=.data$CENSORED), size = dot.size.profile, na.rm=TRUE) +
     geom_line(aes(x=.data$RUN, y=.data$ABUNDANCE, 
-                         color=.data$analysis, linetype=.data$FEATURE), size = 0.5, na.rm=TRUE) + 
+                         color=.data$analysis, linetype=.data$FEATURE), linewidth = 0.5, na.rm=TRUE) + 
     scale_colour_manual(values = c("lightgray", "darkred")) +
     scale_shape_manual(values = c(16, 1),labels = c("Detected data", "Censored missing data")) +
     scale_size_manual(values = c(1.7, 2), guide = "none") +

--- a/R/utils_dataProcessPlots.R
+++ b/R/utils_dataProcessPlots.R
@@ -293,11 +293,11 @@
   
   yaxis.name = 'Log2-intensities'
   ## 1st plot for Protein plot
-  protein_temp = ggplot(aes_string(x = 'xorder', y = 'ABUNDANCE',
-                                    color = 'PSM', linetype = 'PSM'),
+  protein_temp = ggplot(aes(x = .data$xorder, y = .data$ABUNDANCE,
+                                    color = .data$PSM, linetype = .data$PSM),
                          data = sub) +
     facet_grid(~RUN) +
-    geom_point(data = sub, aes(shape=CENSORED), size=dot.size.profile, na.rm=TRUE) +
+    geom_point(data = sub, aes(shape=.data$CENSORED), size=dot.size.profile, na.rm=TRUE) +
     geom_line(size = 0.5, na.rm=TRUE) +
     scale_colour_manual(values=cbp[s]) +
     scale_linetype_manual(values = ss) +
@@ -307,10 +307,10 @@
     scale_y_continuous(yaxis.name, limits = c(y.limdown, y.limup)) +
     scale_x_continuous('MS runs') +
     geom_vline(data = groupline.tmp,
-               aes(xintercept = cumGroupAxis),
+               aes(xintercept = .data$cumGroupAxis),
                colour = "grey", linetype = "longdash") +
     geom_text(data = groupline.all.tmp,
-              aes(x = xorder, y = abundance, label = CONDITION),
+              aes(x = .data$xorder, y = .data$abundance, label = .data$CONDITION),
               size = text.size,
               angle = text.angle, hjust = .9,
               color = "black") +
@@ -418,12 +418,12 @@
   yaxis.name = 'Log2-intensities'
 
   ## Draw summarized ptm plot
-  ptempall = ggplot(aes_string(x = 'xorder', y = 'ABUNDANCE', 
-                                color = 'analysis', linetype = 'PSM', 
-                                size = 'analysis'), data = final) +
+  ptempall = ggplot(aes(x = .data$xorder, y = .data$ABUNDANCE, 
+                                color = .data$analysis, linetype = .data$PSM, 
+                                size = .data$analysis), data = final) +
     facet_grid(~RUN) +
     # geom_point(size = dot.size.profile, na.rm=TRUE) +
-    geom_point(data = final, aes(shape=CENSORED), size=dot.size.profile, na.rm=TRUE) +
+    geom_point(data = final, aes(shape=.data$CENSORED), size=dot.size.profile, na.rm=TRUE) +
     geom_line(size = 0.5, na.rm=TRUE) +
     scale_colour_manual(values = c("lightgray", "darkred")) +
     scale_shape_manual(values = c(16, 1),labels = c("Detected data", "Censored missing data")) +
@@ -434,10 +434,10 @@
          x = 'MS runs') +
     scale_y_continuous(yaxis.name, limits = c(y.limdown, y.limup)) +
     geom_vline(data = groupline.tmp,
-               aes(xintercept = cumGroupAxis),
+               aes(xintercept = .data$cumGroupAxis),
                colour = "grey", linetype = "longdash") +
     geom_text(data = groupline.all.tmp,
-              aes(x = xorder, y = abundance, label = CONDITION),
+              aes(x = .data$xorder, y = .data$abundance, label = .data$CONDITION),
               size = text.size,
               angle = text.angle, hjust = .9,
               color = "black") +
@@ -450,7 +450,7 @@
   
   ## draw point again because some red summary dots could be hiden
   ptempall = ptempall + geom_point(data = final, aes(
-    x = xorder, y = ABUNDANCE, size = analysis, color = analysis)
+    x = .data$xorder, y = .data$ABUNDANCE, size = .data$analysis, color = .data$analysis)
     )
 
   return(ptempall)
@@ -717,18 +717,18 @@
   ## y-axis labeling
   yaxis.name = 'Log2-intensities'
   
-  ptemp = ggplot(aes_string(x = 'xorder', y = 'ABUNDANCE'),
+  ptemp = ggplot(aes(x = .data$xorder, y = .data$ABUNDANCE),
                       data = datafeature) +
     facet_grid(~RUN) +
-    geom_boxplot(aes_string(fill = 'CONDITION'), outlier.shape = 1,
+    geom_boxplot(aes(fill = .data$CONDITION), outlier.shape = 1,
                  outlier.size = 1.5) +
     labs(title = title, x = 'MS runs') +
     scale_y_continuous(yaxis.name, limits = c(ylimdown, ylimup)) +
     geom_vline(data = groupline.tmp,
-               aes(xintercept = cumGroupAxis),
+               aes(xintercept = .data$cumGroupAxis),
                colour = "grey", linetype = "longdash") +
     geom_text(data = groupline.all.tmp,
-              aes(x = xorder, y = abundance, label = CONDITION),
+              aes(x = .data$xorder, y = .data$abundance, label = .data$CONDITION),
               size = text.size,
               angle = text.angle, hjust = .9,
               color = "black") +
@@ -786,18 +786,18 @@
   sub$xorder = factor(sub$xorder)
   yaxis.name = 'Log2-intensities'
   
-  ptemp = ggplot(aes_string(x = 'xorder', y = 'ABUNDANCE'),
+  ptemp = ggplot(aes(x = .data$xorder, y = .data$ABUNDANCE),
                       data = sub) +
     facet_grid(~RUN) +
-    geom_boxplot(aes_string(fill = 'CONDITION'), outlier.shape = 1,
+    geom_boxplot(aes(fill = .data$CONDITION), outlier.shape = 1,
                  outlier.size = 1.5) +
     labs(title = protein, x = 'MS runs') +
     scale_y_continuous(yaxis.name, limits = c(ylimdown, ylimup)) +
     geom_vline(data = groupline.tmp,
-               aes(xintercept = cumGroupAxis),
+               aes(xintercept = .data$cumGroupAxis),
                colour = "grey", linetype = "longdash") +
     geom_text(data = groupline.all.tmp,
-              aes(x = xorder, y = abundance, label = CONDITION),
+              aes(x = .data$xorder, y = .data$abundance, label = .data$CONDITION),
               size = text.size,
               angle = text.angle, hjust = .9,
               color = "black") +
@@ -1141,11 +1141,11 @@
   sub$group_aes = paste(sub$CONDITION, sub$FEATURE, sep = "_")
   ## 1st plot for Protein plot
   protein_temp = ggplot(data=sub) + facet_grid(~LABEL) +
-    geom_point(aes_string(x='RUN', y='ABUNDANCE', 
-                          color='FEATURE',  shape='CENSORED'), #
+    geom_point(aes(x=.data$RUN, y=.data$ABUNDANCE, 
+                          color=.data$FEATURE,  shape=.data$CENSORED), #
                size=dot.size.profile, na.rm=TRUE) +
-    geom_line(aes_string(x='RUN', y='ABUNDANCE', 
-                         color='FEATURE', linetype='FEATURE'), #
+    geom_line(aes(x=.data$RUN, y=.data$ABUNDANCE, 
+                         color=.data$FEATURE, linetype=.data$FEATURE), #
               size = 0.5, na.rm=TRUE) +
     scale_colour_manual(values=cbp[s]) +
     scale_linetype_manual(values = ss) +
@@ -1155,10 +1155,10 @@
     scale_y_continuous(yaxis.name, limits = c(y.limdown, y.limup)) +
     scale_x_continuous('MS runs', breaks=groupNametemp$lineNameAxis) +
     geom_vline(data = groupNametemp[lineNameAxis != 0],
-               aes(xintercept = lineNameAxis + 0.5),
+               aes(xintercept = .data$lineNameAxis + 0.5),
                colour = "grey", linetype = "longdash") +
     geom_text(data = groupNametemp,
-              aes_string(x = "RUN", y = "ABUNDANCE", label = "Name"),
+              aes(x = .data$RUN, y = .data$ABUNDANCE, label = .data$Name),
               size = text.size,
               angle = text.angle, hjust = .9,
               color = "black") +
@@ -1247,10 +1247,10 @@
   
   ## Draw summarized ptm plot
   ptempall = ggplot(data=final) +
-    geom_point(aes_string(x='RUN', y='ABUNDANCE', 
-                          color='analysis', shape='CENSORED'), size = dot.size.profile, na.rm=TRUE) +
-    geom_line(aes_string(x='RUN', y='ABUNDANCE', 
-                         color='analysis', linetype='FEATURE'), size = 0.5, na.rm=TRUE) + 
+    geom_point(aes(x=.data$RUN, y=.data$ABUNDANCE, 
+                          color=.data$analysis, shape=.data$CENSORED), size = dot.size.profile, na.rm=TRUE) +
+    geom_line(aes(x=.data$RUN, y=.data$ABUNDANCE, 
+                         color=.data$analysis, linetype=.data$FEATURE), size = 0.5, na.rm=TRUE) + 
     scale_colour_manual(values = c("lightgray", "darkred")) +
     scale_shape_manual(values = c(16, 1),labels = c("Detected data", "Censored missing data")) +
     scale_size_manual(values = c(1.7, 2), guide = "none") +
@@ -1260,10 +1260,10 @@
          x = 'MS runs') +
     scale_y_continuous(yaxis.name, limits = c(y.limdown, y.limup)) +
     geom_vline(data = groupNametemp[lineNameAxis != 0],
-               aes(xintercept = lineNameAxis + 0.5),
+               aes(xintercept = .data$lineNameAxis + 0.5),
                colour = "grey", linetype = "longdash") +
     geom_text(data = groupNametemp,
-              aes(x = RUN, y = ABUNDANCE, label = Name),
+              aes(x = .data$RUN, y = .data$ABUNDANCE, label = .data$Name),
               size = text.size,
               angle = text.angle, hjust = .9,
               color = "black") +
@@ -1528,17 +1528,17 @@
   ## y-axis labeling
   yaxis.name = 'Log-intensities'
   
-  ptemp = ggplot(aes_string(x = 'RUN', y = 'ABUNDANCE'),
+  ptemp = ggplot(aes(x = .data$RUN, y = .data$ABUNDANCE),
                   data = datafeature) +
-    geom_boxplot(aes_string(fill = 'CONDITION'), outlier.shape = 1,
+    geom_boxplot(aes(fill = .data$CONDITION), outlier.shape = 1,
                  outlier.size = 1.5) +
     labs(title = title, x = 'MS runs') +
     scale_y_continuous(yaxis.name, y.limdown, y.limup) +
     geom_vline(data = groupName.tmp[lineNameAxis != 0],
-               aes(xintercept = lineNameAxis + 0.5),
+               aes(xintercept = .data$lineNameAxis + 0.5),
                colour = "grey", linetype = "longdash") +
     geom_text(data = groupName.tmp,
-              aes(x = RUN, y = ABUNDANCE - 1, label = Name),
+              aes(x = .data$RUN, y = .data$ABUNDANCE - 1, label = .data$Name),
               size = text.size,
               angle = 0,color = "black") +
     theme_msstats(type = "PROFILEPLOT", x.axis.size, y.axis.size,
@@ -1587,17 +1587,17 @@
   ## for boxplot, x-axis, xorder should be factor
   yaxis.name = 'Log-intensities'
   
-  ptemp = ggplot(aes_string(x = 'RUN', y = 'ABUNDANCE'),
+  ptemp = ggplot(aes(x = .data$RUN, y = .data$ABUNDANCE),
                   data = sub) +
-    geom_boxplot(aes_string(fill = 'CONDITION'), outlier.shape = 1,
+    geom_boxplot(aes(fill = .data$CONDITION), outlier.shape = 1,
                  outlier.size = 1.5) +
     labs(title = protein, x = 'MS runs') +
     scale_y_continuous(yaxis.name, limits = c(y.limdown, y.limup)) +
     geom_vline(data = groupname.tmp[lineNameAxis != 0],
-               aes(xintercept = lineNameAxis + .5),
+               aes(xintercept = .data$lineNameAxis + .5),
                colour = "grey", linetype = "longdash") +
     geom_text(data = groupname.tmp,
-              aes(x = RUN, y = ABUNDANCE, label = Name),
+              aes(x = .data$RUN, y = .data$ABUNDANCE, label = .data$Name),
               size = text.size,
               color = "black") +
     theme_msstats(type = "PROFILEPLOT", x.axis.size, y.axis.size,

--- a/R/utils_groupComparisonPlots.R
+++ b/R/utils_groupComparisonPlots.R
@@ -581,7 +581,7 @@
         geom_line(data=sigcut,
                   aes(x = .data$logFC, y = .data$logadjp, linetype = .data$line),
                   colour="darkgrey",
-                  size=0.6,
+                  linewidth=0.6,
                   show.legend=TRUE) +
         scale_linetype_manual(values=c('twodash'=6),
                               labels=c(paste0("Adj p-value cutoff (", sig, ")"))
@@ -624,17 +624,17 @@
         geom_line(data=sigcut, 
                   aes(x = .data$logFC, y = .data$logadjp, linetype = .data$line),
                   colour="darkgrey",
-                  size=0.6,
+                  linewidth=0.6,
                   show.legend=TRUE) +
         geom_line(data=FCcutpos,
                   aes(x = .data$logFC, y = .data$logadjp, linetype = .data$line),
                   colour="darkgrey",
-                  size=0.6,
+                  linewidth=0.6,
                   show.legend=TRUE) +
         geom_line(data=FCcutneg,
                   aes(x = .data$logFC, y = .data$logadjp, linetype = .data$line),
                   colour="darkgrey",
-                  size=0.6) +
+                  linewidth=0.6) +
         scale_linetype_manual(values=c('dotted'=3, 'twodash'=6),
                               labels=c(paste0("Fold change cutoff (", FCcutoff, 
                                               ")"),

--- a/R/utils_groupComparisonPlots.R
+++ b/R/utils_groupComparisonPlots.R
@@ -302,7 +302,7 @@
       
       limits = c(-1,1)*max(abs(temp_obj$sign_adj_pval[
         is.finite(temp_obj$sign_adj_pval)]))
-      temp_heatmap = ggplot(temp_obj, aes(Label, Protein, fill = sign_adj_pval)
+      temp_heatmap = ggplot(temp_obj, aes(.data$Label, .data$Protein, fill = .data$sign_adj_pval)
       ) + geom_tile() + scale_fill_distiller(
         palette = "RdBu", name = "(sign) Adj pvalue",
         limits = limits) + labs(
@@ -528,9 +528,9 @@
       log_title = 'Log10'
     }
     
-    ptemp = ggplot(aes_string(x='logFC', y='logadjp',
-                               color='colgroup',
-                               label='Protein'),
+    ptemp = ggplot(aes(x = .data$logFC, y = .data$logadjp,
+                               color = .data$colgroup,
+                               label = .data$Protein),
                     data=subtemp) +
       geom_point(size=dot.size) +
       scale_colour_manual(values=c("gray65", "blue", "red"), 
@@ -553,7 +553,7 @@
       } else {
         ptemp = ptemp +
           geom_text_repel(data=subtemp[subtemp$colgroup != "black", ],
-                          aes(label=Protein),
+                          aes(label = .data$Protein),
                           size=text.size,
                           col='black')
       }
@@ -579,7 +579,7 @@
       
       pfinal = ptemp +
         geom_line(data=sigcut,
-                  aes_string(x='logFC', y='logadjp', linetype='line'),
+                  aes(x = .data$logFC, y = .data$logadjp, linetype = .data$line),
                   colour="darkgrey",
                   size=0.6,
                   show.legend=TRUE) +
@@ -622,17 +622,17 @@
       ## three lines, with order color first and then assign linetype manual
       pfinal = ptemp +
         geom_line(data=sigcut, 
-                  aes_string(x='logFC', y='logadjp', linetype='line'),
+                  aes(x = .data$logFC, y = .data$logadjp, linetype = .data$line),
                   colour="darkgrey",
                   size=0.6,
                   show.legend=TRUE) +
         geom_line(data=FCcutpos,
-                  aes_string(x='logFC', y='logadjp', linetype='line'),
+                  aes(x = .data$logFC, y = .data$logadjp, linetype = .data$line),
                   colour="darkgrey",
                   size=0.6,
                   show.legend=TRUE) +
         geom_line(data=FCcutneg,
-                  aes_string(x='logFC', y='logadjp', linetype='line'),
+                  aes(x = .data$logFC, y = .data$logadjp, linetype = .data$line),
                   colour="darkgrey",
                   size=0.6) +
         scale_linetype_manual(values=c('dotted'=3, 'twodash'=6),


### PR DESCRIPTION
# Motivation and Context

MSstatsLiP build is failing because it relies on dataProcessPlotsPTM and groupComparisonPlotsPTM, which are emitting warnings for using deprecated ggplot functions.

## Changes

- Migrate from aes_string to aes
- Migrate from size to linewidth for geom_line, geom_hline functions

## Testing

MSstatsLiP build succeeds now

## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Improved compatibility with recent ggplot2 by replacing deprecated aes_string and size in geom_line, reducing warnings/errors in plots.
* Refactor
  * Migrated all plotting routines to tidy-evaluation using .data for column references, ensuring consistent and explicit aesthetic mappings across protein/PTM, summary, QC, heatmap, and volcano plots.
  * Standardized line widths using linewidth for clearer visuals.
* Chores
  * General code modernization and consistency updates across plotting functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->