### PR TITLE
deprecation(groupComparisonPTM): Deprecate data.type parameter

### DIFF
--- a/R/groupComparisonPTM.R
+++ b/R/groupComparisonPTM.R
@@ -19,8 +19,6 @@
 #' function \code{\link[MSstatsPTM]{dataSummarizationPTM}}  or 
 #' \code{\link[MSstatsPTM]{dataSummarizationPTM_TMT}} depending on acquisition
 #' type.
-#' @param data.type Type of data. Must be one of `LF` or `TMT`. Will be deprecated 
-#' in favor of ptm_label_type and protein_label_type.
 #' @param contrast.matrix comparison between conditions of interests. Default 
 #' models full pairwise comparison between all conditions
 #' @param moderated For TMT experiments only. TRUE will moderate t statistic; 
@@ -56,8 +54,9 @@
 #'                                      protein_label_type="LF",
 #'                                      verbose = FALSE)
 groupComparisonPTM = function(data, 
-                              data.type = NULL,
                               contrast.matrix = "pairwise",
+                              ptm_label_type = "LF",
+                              protein_label_type = "LF",
                               moderated = FALSE, 
                               adj.method = "BH",
                               log_base = 2,
@@ -66,35 +65,7 @@ groupComparisonPTM = function(data,
                               append = FALSE,
                               verbose = TRUE, 
                               log_file_path = NULL,
-                              base = "MSstatsPTM_log_",
-                              ptm_label_type = "LF",
-                              protein_label_type = "LF") {
-  
-  ## Start log  
-  # if (is.null(log_file_path) & use_log_file == TRUE){
-  #   time_now = Sys.time()
-  #   path = paste0(base, gsub("[ :\\-]", "_", time_now), 
-  #                 ".log")
-  #   file.create(path)
-  # } else {path = log_file_path}
-  # 
-  # if (data.type == 'TMT'){
-  #   pkg = "MSstatsTMT"
-  #   option_log = "MSstatsTMTLog"
-  # } else {
-  #   pkg = "MSstats"
-  #   option_log = "MSstatsLog"
-  # }
-  # 
-  # MSstatsLogsSettings(use_log_file, append,
-  #                     verbose, log_file_path = path, 
-  #                     pkg_name = pkg)
-  
-  # getOption(option_log)("INFO", "Starting parameter and data checks..")
-  if (!is.null(data.type) && (data.type == "TMT" || data.type == "LF")) {
-      ptm_label_type = data.type
-      protein_label_type = data.type
-  }
+                              base = "MSstatsPTM_log_") {
   
   Label = Site = NULL
   
@@ -241,12 +212,6 @@ groupComparisonPTM = function(data,
                   'ADJUSTED.Model'=adjusted_models, 
                   'Model.Details'=list('PTM'=ptm_model_details,
                                        'PROTEIN'=protein_model_details))
-  }
-  
-  if (!is.null(data.type) && (data.type == "TMT" || data.type == "LF")) {
-      warning("DEPRECATION NOTICE: The `data.type` argument is being deprecated. 
-              Please use `ptm_label_type` and `protein_label_type` instead ahead
-              of Release 3.22")
   }
 
   return(models)

--- a/R/groupComparisonPTM.R
+++ b/R/groupComparisonPTM.R
@@ -21,6 +21,14 @@
 #' type.
 #' @param contrast.matrix comparison between conditions of interests. Default 
 #' models full pairwise comparison between all conditions
+#' @param ptm_label_type Type of quantification used in the PTM dataset. 
+#' Must be either `"LF"` (label-free) or `"TMT"` (Tandem Mass Tag isobaric labeling).
+#' Choose `"LF"` for label-free quantification or `"TMT"` for TMT-labeled experiments.
+#' Default is `"LF"`.
+#' @param protein_label_type Type of quantification used in the protein dataset.
+#' Must be either `"LF"` (label-free) or `"TMT"` (Tandem Mass Tag isobaric labeling).
+#' Choose `"LF"` for label-free quantification or `"TMT"` for TMT-labeled experiments.
+#' Default is `"LF"`.
 #' @param moderated For TMT experiments only. TRUE will moderate t statistic; 
 #' FALSE (default) uses ordinary t statistic. Default is FALSE.
 #' @param adj.method For TMT experiments only. Adjusted method for multiple 
@@ -40,10 +48,6 @@
 #' If not provided, such a file will be created automatically.
 #' If `append = TRUE`, has to be a valid path to a file.
 #' @param base start of the file name.
-#' @param ptm_label_type Indicator of labeling type for PTM dataset. Must be one
-#' of `LF` or `TMT`
-#' @param protein_label_type Indicator of labeling type for PROTEIN dataset. 
-#' Must be one of `LF` or `TMT`
 #' @return list of modeling results. Includes PTM, PROTEIN, and ADJUSTED
 #'         data.tables with their corresponding model results.
 #'         
@@ -55,8 +59,8 @@
 #'                                      verbose = FALSE)
 groupComparisonPTM = function(data, 
                               contrast.matrix = "pairwise",
-                              ptm_label_type = "LF",
-                              protein_label_type = "LF",
+                              ptm_label_type = c("LF", "TMT"),
+                              protein_label_type = c("LF", "TMT"),
                               moderated = FALSE, 
                               adj.method = "BH",
                               log_base = 2,
@@ -68,6 +72,8 @@ groupComparisonPTM = function(data,
                               base = "MSstatsPTM_log_") {
   
   Label = Site = NULL
+  ptm_label_type = match.arg(ptm_label_type)
+  protein_label_type = match.arg(protein_label_type)
   
   data.ptm = data[["PTM"]]
   data.protein = data[["PROTEIN"]]

--- a/R/groupComparisonPTM.R
+++ b/R/groupComparisonPTM.R
@@ -88,7 +88,6 @@ groupComparisonPTM = function(data,
   
   ## Create pairwise matrix for label free
   if (contrast.matrix[1] == "pairwise"){
-    # getOption(option_log)("INFO", "Building pairwise matrix.")
     if ("GROUP" %in% colnames(data.ptm$ProteinLevelData)) {
       labels <- unique(data.ptm$ProteinLevelData$GROUP)
     } else if ("Condition" %in% colnames(data.ptm$ProteinLevelData)) {
@@ -102,7 +101,6 @@ groupComparisonPTM = function(data,
   ## PTM Modeling
   message("Starting PTM modeling...")
   if (ptm_label_type == "TMT"){
-    # getOption(option_log)("INFO", "Starting TMT PTM Model")
     ptm_model_full = groupComparisonTMT(data.ptm, 
                                         contrast.matrix = contrast.matrix,
                                         moderated = moderated, 
@@ -116,7 +114,6 @@ groupComparisonPTM = function(data,
     ptm_model_site_sep = ptm_model_full$ComparisonResult
     ptm_model_details = ptm_model_full$FittedModel
   } else if (ptm_label_type == "LF") {
-    # getOption(option_log)("INFO", "Starting non-TMT PTM Model")
     ptm_model_full = groupComparison(contrast.matrix,
                                       data.ptm, save_fitted_models, log_base)#, 
                                       # use_log_file, append, verbose, 
@@ -133,7 +130,6 @@ groupComparisonPTM = function(data,
     ## Protein Modeling
     message("Starting Protein modeling...")
     if (protein_label_type == "TMT"){
-      # getOption(option_log)("INFO", "Starting TMT Protein Model")
       protein_model_full = groupComparisonTMT(data.protein, 
                                           contrast.matrix = contrast.matrix,
                                           moderated = moderated, 
@@ -146,7 +142,6 @@ groupComparisonPTM = function(data,
       protein_model = protein_model_full$ComparisonResult
       protein_model_details = protein_model_full$FittedModel
     } else if (protein_label_type == "LF") {
-      # getOption(option_log)("INFO", "Starting non-TMT Protein Model")
       protein_model_full = groupComparison(contrast.matrix, 
                                            data.protein, save_fitted_models, 
                                            log_base, use_log_file)#, 
@@ -160,20 +155,16 @@ groupComparisonPTM = function(data,
     protein_model = as.data.table(protein_model)
     
     message("Starting adjustment...")
-    # getOption(option_log)("INFO", "Starting Protein Adjustment")
     ptm_model_site_sep = copy(ptm_model)
     
     ## extract global protein name
     ptm_model_site_sep = .extractProtein(ptm_model_site_sep, protein_model)
-    # getOption(option_log)("INFO", "Rcpp function extracted protein info")
     
     ## adjustProteinLevel function can only compare one label at a time
     comparisons = unique(ptm_model_site_sep[, Label])
     
     adjusted_model_list = list()
     for (i in seq_len(length(comparisons))) {
-      # getOption(option_log)("INFO", paste0("Adjusting for Comparison - ", 
-                                             # as.character(i)))
       temp_adjusted_model = .applyPtmAdjustment(comparisons[[i]],
                                                    ptm_model_site_sep,
                                                    protein_model)
@@ -212,7 +203,6 @@ groupComparisonPTM = function(data,
                                 use.names=TRUE)
     adjusted_models = adjusted_models[!is.na(adjusted_models$Protein)]
     
-    # getOption(option_log)("INFO", "Adjustment complete, returning models.")
     models = list('PTM.Model'=ptm_model, 
                   'PROTEIN.Model'=protein_model,
                   'ADJUSTED.Model'=adjusted_models, 

--- a/man/groupComparisonPTM.Rd
+++ b/man/groupComparisonPTM.Rd
@@ -7,8 +7,8 @@
 groupComparisonPTM(
   data,
   contrast.matrix = "pairwise",
-  ptm_label_type = "LF",
-  protein_label_type = "LF",
+  ptm_label_type = c("LF", "TMT"),
+  protein_label_type = c("LF", "TMT"),
   moderated = FALSE,
   adj.method = "BH",
   log_base = 2,
@@ -29,11 +29,15 @@ type.}
 \item{contrast.matrix}{comparison between conditions of interests. Default
 models full pairwise comparison between all conditions}
 
-\item{ptm_label_type}{Indicator of labeling type for PTM dataset. Must be one
-of \code{LF} or \code{TMT}}
+\item{ptm_label_type}{Type of quantification used in the PTM dataset.
+Must be either \code{"LF"} (label-free) or \code{"TMT"} (Tandem Mass Tag isobaric labeling).
+Choose \code{"LF"} for label-free quantification or \code{"TMT"} for TMT-labeled experiments.
+Default is \code{"LF"}.}
 
-\item{protein_label_type}{Indicator of labeling type for PROTEIN dataset.
-Must be one of \code{LF} or \code{TMT}}
+\item{protein_label_type}{Type of quantification used in the protein dataset.
+Must be either \code{"LF"} (label-free) or \code{"TMT"} (Tandem Mass Tag isobaric labeling).
+Choose \code{"LF"} for label-free quantification or \code{"TMT"} for TMT-labeled experiments.
+Default is \code{"LF"}.}
 
 \item{moderated}{For TMT experiments only. TRUE will moderate t statistic;
 FALSE (default) uses ordinary t statistic. Default is FALSE.}

--- a/man/groupComparisonPTM.Rd
+++ b/man/groupComparisonPTM.Rd
@@ -6,8 +6,9 @@
 \usage{
 groupComparisonPTM(
   data,
-  data.type = NULL,
   contrast.matrix = "pairwise",
+  ptm_label_type = "LF",
+  protein_label_type = "LF",
   moderated = FALSE,
   adj.method = "BH",
   log_base = 2,
@@ -16,9 +17,7 @@ groupComparisonPTM(
   append = FALSE,
   verbose = TRUE,
   log_file_path = NULL,
-  base = "MSstatsPTM_log_",
-  ptm_label_type = "LF",
-  protein_label_type = "LF"
+  base = "MSstatsPTM_log_"
 )
 }
 \arguments{
@@ -27,11 +26,14 @@ function \code{\link[MSstatsPTM]{dataSummarizationPTM}}  or
 \code{\link[MSstatsPTM]{dataSummarizationPTM_TMT}} depending on acquisition
 type.}
 
-\item{data.type}{Type of data. Must be one of \code{LF} or \code{TMT}. Will be deprecated
-in favor of ptm_label_type and protein_label_type.}
-
 \item{contrast.matrix}{comparison between conditions of interests. Default
 models full pairwise comparison between all conditions}
+
+\item{ptm_label_type}{Indicator of labeling type for PTM dataset. Must be one
+of \code{LF} or \code{TMT}}
+
+\item{protein_label_type}{Indicator of labeling type for PROTEIN dataset.
+Must be one of \code{LF} or \code{TMT}}
 
 \item{moderated}{For TMT experiments only. TRUE will moderate t statistic;
 FALSE (default) uses ordinary t statistic. Default is FALSE.}
@@ -60,12 +62,6 @@ If not provided, such a file will be created automatically.
 If \code{append = TRUE}, has to be a valid path to a file.}
 
 \item{base}{start of the file name.}
-
-\item{ptm_label_type}{Indicator of labeling type for PTM dataset. Must be one
-of \code{LF} or \code{TMT}}
-
-\item{protein_label_type}{Indicator of labeling type for PROTEIN dataset.
-Must be one of \code{LF} or \code{TMT}}
 }
 \value{
 list of modeling results. Includes PTM, PROTEIN, and ADJUSTED


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Replaced the single legacy labeling parameter with two explicit public parameters to select labeling types for PTM and protein data; callers must now specify PTM and protein label types separately.

* **Documentation**
  * Updated user-facing docs and usage examples to reflect the new parameter names, accepted values, and defaults for PTM and protein labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->