### PR TITLE
Revert "deprecation(groupComparisonPTM): Deprecate data.type parameter

### DIFF
--- a/R/groupComparisonPTM.R
+++ b/R/groupComparisonPTM.R
@@ -19,16 +19,10 @@
 #' function \code{\link[MSstatsPTM]{dataSummarizationPTM}}  or 
 #' \code{\link[MSstatsPTM]{dataSummarizationPTM_TMT}} depending on acquisition
 #' type.
+#' @param data.type Type of data. Must be one of `LF` or `TMT`. Will be deprecated 
+#' in favor of ptm_label_type and protein_label_type.
 #' @param contrast.matrix comparison between conditions of interests. Default 
 #' models full pairwise comparison between all conditions
-#' @param ptm_label_type Type of quantification used in the PTM dataset. 
-#' Must be either `"LF"` (label-free) or `"TMT"` (Tandem Mass Tag isobaric labeling).
-#' Choose `"LF"` for label-free quantification or `"TMT"` for TMT-labeled experiments.
-#' Default is `"LF"`.
-#' @param protein_label_type Type of quantification used in the protein dataset.
-#' Must be either `"LF"` (label-free) or `"TMT"` (Tandem Mass Tag isobaric labeling).
-#' Choose `"LF"` for label-free quantification or `"TMT"` for TMT-labeled experiments.
-#' Default is `"LF"`.
 #' @param moderated For TMT experiments only. TRUE will moderate t statistic; 
 #' FALSE (default) uses ordinary t statistic. Default is FALSE.
 #' @param adj.method For TMT experiments only. Adjusted method for multiple 
@@ -48,6 +42,10 @@
 #' If not provided, such a file will be created automatically.
 #' If `append = TRUE`, has to be a valid path to a file.
 #' @param base start of the file name.
+#' @param ptm_label_type Indicator of labeling type for PTM dataset. Must be one
+#' of `LF` or `TMT`
+#' @param protein_label_type Indicator of labeling type for PROTEIN dataset. 
+#' Must be one of `LF` or `TMT`
 #' @return list of modeling results. Includes PTM, PROTEIN, and ADJUSTED
 #'         data.tables with their corresponding model results.
 #'         
@@ -58,9 +56,8 @@
 #'                                      protein_label_type="LF",
 #'                                      verbose = FALSE)
 groupComparisonPTM = function(data, 
+                              data.type = NULL,
                               contrast.matrix = "pairwise",
-                              ptm_label_type = c("LF", "TMT"),
-                              protein_label_type = c("LF", "TMT"),
                               moderated = FALSE, 
                               adj.method = "BH",
                               log_base = 2,
@@ -69,11 +66,37 @@ groupComparisonPTM = function(data,
                               append = FALSE,
                               verbose = TRUE, 
                               log_file_path = NULL,
-                              base = "MSstatsPTM_log_") {
+                              base = "MSstatsPTM_log_",
+                              ptm_label_type = "LF",
+                              protein_label_type = "LF") {
+  
+  ## Start log  
+  # if (is.null(log_file_path) & use_log_file == TRUE){
+  #   time_now = Sys.time()
+  #   path = paste0(base, gsub("[ :\\-]", "_", time_now), 
+  #                 ".log")
+  #   file.create(path)
+  # } else {path = log_file_path}
+  # 
+  # if (data.type == 'TMT'){
+  #   pkg = "MSstatsTMT"
+  #   option_log = "MSstatsTMTLog"
+  # } else {
+  #   pkg = "MSstats"
+  #   option_log = "MSstatsLog"
+  # }
+  # 
+  # MSstatsLogsSettings(use_log_file, append,
+  #                     verbose, log_file_path = path, 
+  #                     pkg_name = pkg)
+  
+  # getOption(option_log)("INFO", "Starting parameter and data checks..")
+  if (!is.null(data.type) && (data.type == "TMT" || data.type == "LF")) {
+      ptm_label_type = data.type
+      protein_label_type = data.type
+  }
   
   Label = Site = NULL
-  ptm_label_type = match.arg(ptm_label_type)
-  protein_label_type = match.arg(protein_label_type)
   
   data.ptm = data[["PTM"]]
   data.protein = data[["PROTEIN"]]
@@ -88,6 +111,7 @@ groupComparisonPTM = function(data,
   
   ## Create pairwise matrix for label free
   if (contrast.matrix[1] == "pairwise"){
+    # getOption(option_log)("INFO", "Building pairwise matrix.")
     if ("GROUP" %in% colnames(data.ptm$ProteinLevelData)) {
       labels <- unique(data.ptm$ProteinLevelData$GROUP)
     } else if ("Condition" %in% colnames(data.ptm$ProteinLevelData)) {
@@ -101,6 +125,7 @@ groupComparisonPTM = function(data,
   ## PTM Modeling
   message("Starting PTM modeling...")
   if (ptm_label_type == "TMT"){
+    # getOption(option_log)("INFO", "Starting TMT PTM Model")
     ptm_model_full = groupComparisonTMT(data.ptm, 
                                         contrast.matrix = contrast.matrix,
                                         moderated = moderated, 
@@ -114,6 +139,7 @@ groupComparisonPTM = function(data,
     ptm_model_site_sep = ptm_model_full$ComparisonResult
     ptm_model_details = ptm_model_full$FittedModel
   } else if (ptm_label_type == "LF") {
+    # getOption(option_log)("INFO", "Starting non-TMT PTM Model")
     ptm_model_full = groupComparison(contrast.matrix,
                                       data.ptm, save_fitted_models, log_base)#, 
                                       # use_log_file, append, verbose, 
@@ -130,6 +156,7 @@ groupComparisonPTM = function(data,
     ## Protein Modeling
     message("Starting Protein modeling...")
     if (protein_label_type == "TMT"){
+      # getOption(option_log)("INFO", "Starting TMT Protein Model")
       protein_model_full = groupComparisonTMT(data.protein, 
                                           contrast.matrix = contrast.matrix,
                                           moderated = moderated, 
@@ -142,6 +169,7 @@ groupComparisonPTM = function(data,
       protein_model = protein_model_full$ComparisonResult
       protein_model_details = protein_model_full$FittedModel
     } else if (protein_label_type == "LF") {
+      # getOption(option_log)("INFO", "Starting non-TMT Protein Model")
       protein_model_full = groupComparison(contrast.matrix, 
                                            data.protein, save_fitted_models, 
                                            log_base, use_log_file)#, 
@@ -155,16 +183,20 @@ groupComparisonPTM = function(data,
     protein_model = as.data.table(protein_model)
     
     message("Starting adjustment...")
+    # getOption(option_log)("INFO", "Starting Protein Adjustment")
     ptm_model_site_sep = copy(ptm_model)
     
     ## extract global protein name
     ptm_model_site_sep = .extractProtein(ptm_model_site_sep, protein_model)
+    # getOption(option_log)("INFO", "Rcpp function extracted protein info")
     
     ## adjustProteinLevel function can only compare one label at a time
     comparisons = unique(ptm_model_site_sep[, Label])
     
     adjusted_model_list = list()
     for (i in seq_len(length(comparisons))) {
+      # getOption(option_log)("INFO", paste0("Adjusting for Comparison - ", 
+                                             # as.character(i)))
       temp_adjusted_model = .applyPtmAdjustment(comparisons[[i]],
                                                    ptm_model_site_sep,
                                                    protein_model)
@@ -203,11 +235,18 @@ groupComparisonPTM = function(data,
                                 use.names=TRUE)
     adjusted_models = adjusted_models[!is.na(adjusted_models$Protein)]
     
+    # getOption(option_log)("INFO", "Adjustment complete, returning models.")
     models = list('PTM.Model'=ptm_model, 
                   'PROTEIN.Model'=protein_model,
                   'ADJUSTED.Model'=adjusted_models, 
                   'Model.Details'=list('PTM'=ptm_model_details,
                                        'PROTEIN'=protein_model_details))
+  }
+  
+  if (!is.null(data.type) && (data.type == "TMT" || data.type == "LF")) {
+      warning("DEPRECATION NOTICE: The `data.type` argument is being deprecated. 
+              Please use `ptm_label_type` and `protein_label_type` instead ahead
+              of Release 3.22")
   }
 
   return(models)

--- a/man/groupComparisonPTM.Rd
+++ b/man/groupComparisonPTM.Rd
@@ -6,9 +6,8 @@
 \usage{
 groupComparisonPTM(
   data,
+  data.type = NULL,
   contrast.matrix = "pairwise",
-  ptm_label_type = c("LF", "TMT"),
-  protein_label_type = c("LF", "TMT"),
   moderated = FALSE,
   adj.method = "BH",
   log_base = 2,
@@ -17,7 +16,9 @@ groupComparisonPTM(
   append = FALSE,
   verbose = TRUE,
   log_file_path = NULL,
-  base = "MSstatsPTM_log_"
+  base = "MSstatsPTM_log_",
+  ptm_label_type = "LF",
+  protein_label_type = "LF"
 )
 }
 \arguments{
@@ -26,18 +27,11 @@ function \code{\link[MSstatsPTM]{dataSummarizationPTM}}  or
 \code{\link[MSstatsPTM]{dataSummarizationPTM_TMT}} depending on acquisition
 type.}
 
+\item{data.type}{Type of data. Must be one of \code{LF} or \code{TMT}. Will be deprecated
+in favor of ptm_label_type and protein_label_type.}
+
 \item{contrast.matrix}{comparison between conditions of interests. Default
 models full pairwise comparison between all conditions}
-
-\item{ptm_label_type}{Type of quantification used in the PTM dataset.
-Must be either \code{"LF"} (label-free) or \code{"TMT"} (Tandem Mass Tag isobaric labeling).
-Choose \code{"LF"} for label-free quantification or \code{"TMT"} for TMT-labeled experiments.
-Default is \code{"LF"}.}
-
-\item{protein_label_type}{Type of quantification used in the protein dataset.
-Must be either \code{"LF"} (label-free) or \code{"TMT"} (Tandem Mass Tag isobaric labeling).
-Choose \code{"LF"} for label-free quantification or \code{"TMT"} for TMT-labeled experiments.
-Default is \code{"LF"}.}
 
 \item{moderated}{For TMT experiments only. TRUE will moderate t statistic;
 FALSE (default) uses ordinary t statistic. Default is FALSE.}
@@ -66,6 +60,12 @@ If not provided, such a file will be created automatically.
 If \code{append = TRUE}, has to be a valid path to a file.}
 
 \item{base}{start of the file name.}
+
+\item{ptm_label_type}{Indicator of labeling type for PTM dataset. Must be one
+of \code{LF} or \code{TMT}}
+
+\item{protein_label_type}{Indicator of labeling type for PROTEIN dataset.
+Must be one of \code{LF} or \code{TMT}}
 }
 \value{
 list of modeling results. Includes PTM, PROTEIN, and ADJUSTED


### PR DESCRIPTION
This reverts commit 0630b4346704ebebd20241cc0d1a7c27f225337b.  I'm thinking we should wait for a major release (like upgrading MSstatsPTM to 3.x) before doing a change that is not backwards compatibility.  Plus we should do this during a release that's not before May Institute.

# Motivation and Context

Please include relevant motivation and context of the problem along with a short summary of the solution.

## Changes

Please provide a detailed bullet point list of your changes.

- 

## Testing

Please describe any unit tests you added or modified to verify your changes.

## Checklist Before Requesting a Review
- [ ] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Motivation and Context

This PR reverts commit 0630b43 which deprecated the `data.type` parameter in the `groupComparisonPTM()` function. The reversion is necessary to maintain backward compatibility with existing code. The author postpones the removal of `data.type` until a major release (e.g., MSstatsPTM 3.x) rather than removing it in the current development version to avoid breaking changes for existing users who rely on the parameter.

## Changes

- **Function signature restoration in `R/groupComparisonPTM.R`:**
  - Restored `data.type = NULL` parameter as the second argument in the function signature
  - Reverted `ptm_label_type` default from `c("LF", "TMT")` (with match.arg validation) back to scalar `"LF"`
  - Reverted `protein_label_type` default from `c("LF", "TMT")` (with match.arg validation) back to scalar `"LF"`
  - Moved both label type parameters to the end of the function signature (after `base` parameter)
  - Restored the conditional logic that maps `data.type` values to `ptm_label_type` and `protein_label_type` when `data.type` is provided
  - Restored the deprecation warning at function end, alerting users that `data.type` will be deprecated in favor of the two label-type arguments prior to Release 3.22
  - Removed `match.arg()` validation calls on the label type parameters

- **Documentation restoration in `man/groupComparisonPTM.Rd`:**
  - Restored `data.type = NULL` parameter documentation
  - Moved `ptm_label_type` and `protein_label_type` back to end of parameter list with scalar defaults `"LF"`
  - Shortened documentation descriptions for label type parameters back to simple indicators
  - Removed the expanded documentation that was added to clarify the label type parameters in the deprecation commit

- **Infrastructure files added:**
  - `.Rbuildignore`: Standard R package build exclusions
  - `.gitignore`: Repository exclusions for R artifacts
  - `.travis.yml`: Travis CI configuration
  - `.github/pull_request_template.md`: Pull request template with sections for motivation, changes, testing, and checklist
  - `.github/workflows/dry-run-build.yml`: GitHub Actions workflow for PR builds and checks

## Testing

The existing tests in `inst/tinytest/test_groupComparisonPTM.R` remain valid and continue to use the explicit `ptm_label_type` and `protein_label_type` parameters with their scalar values (`"LF"` and `"TMT"`). The tests do not require modification as they were already adapted to use the explicit label type parameters rather than the `data.type` parameter.

## Coding Guidelines

No coding guideline violations are introduced. The reversion maintains consistent parameter handling and documentation practices with the pre-deprecation code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->