### PR TITLE
fix(dataProcessPlotsPTM): Fix documentation around originalPlots parameter

### DIFF
--- a/R/dataProcessPlotsPTM.R
+++ b/R/dataProcessPlotsPTM.R
@@ -52,7 +52,7 @@
 #' @param which.Protein List of proteins to plot. Will plot all PTMs associated 
 #' with listed Proteins. Default is NULL which will default to which.PTM.
 #' @param originalPlot TRUE(default) draws original profile plots, without
-#' normalization.
+#' summarization.
 #' @param summaryPlot TRUE(default) draws profile plots with protein
 #' summarization for each channel and MS run.
 #' @param address the name of folder that will store the results. Default folder

--- a/man/DIANNtoMSstatsPTMFormat.Rd
+++ b/man/DIANNtoMSstatsPTMFormat.Rd
@@ -84,7 +84,7 @@ will be saved to a file.}
 \item{append}{logical. If TRUE, information about data processing will be added
 to an existing log file.}
 
-\item{verbose}{logical. If TRUE, information about data processing wil be printed
+\item{verbose}{logical. If TRUE, information about data processing will be printed
 to the console.}
 
 \item{log_file_path}{character. Path to a file to which information about

--- a/man/dataProcessPlotsPTM.Rd
+++ b/man/dataProcessPlotsPTM.Rd
@@ -80,7 +80,7 @@ Default is "all", which generates all plots for each protein. For QC plot,
 with listed Proteins. Default is NULL which will default to which.PTM.}
 
 \item{originalPlot}{TRUE(default) draws original profile plots, without
-normalization.}
+summarization.}
 
 \item{summaryPlot}{TRUE(default) draws profile plots with protein
 summarization for each channel and MS run.}


### PR DESCRIPTION


# Motivation and Context

Documentation was confusing w.r.t what the originalPlots parameter does, leading to confusion with implementation in MSstatsShiny

## Changes

Please provide a detailed bullet point list of your changes.

- Clarify that originalPlots is the profile plot without summarization,  not normalization.


## Checklist Before Requesting a Review
- [x] I have read the MSstats [contributing guidelines](https://github.com/Vitek-Lab/MSstatsConvert/blob/master/.github/CONTRIBUTING.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules