### PR TITLE
fix(groupComparisonPlots): fix bug around printing

### DIFF
--- a/R/utils_groupComparisonPlots.R
+++ b/R/utils_groupComparisonPlots.R
@@ -665,7 +665,7 @@
       #   legend.title = element_blank()
       # )
     
-    print(pfinal)
+    if (!isPlotly) print(pfinal)
     plots[[i]] = pfinal
   }
   if (isPlotly) {


### PR DESCRIPTION
# Motivation and Context

Got an error w.r.t. renderPlotly:  ` getting the error no applicable method for 'plotly_build' applied to an object of class       "character".  Viewport dimensions has zero  `

The error chain is:

1. .plot.model.volcano calls print(pfinal) unconditionally (line 668 in utils_groupComparisonPlots.R) even when isPlotly = TRUE, which tries to render to the Shiny graphics device — causing "Viewport dimensions has zero"       
2. That error is caught by the tryCatch in create_group_comparison_plot, whose error handler returns the character notification ID from showNotification
3. renderPlotly receives that character string → "no applicable method for 'plotly_build' applied to an object of class 'character'

