### PR TITLE
Ylim down

### DIFF
--- a/R/dataProcessPlotsPTM.R
+++ b/R/dataProcessPlotsPTM.R
@@ -29,7 +29,8 @@
 #' FALSE(Default) for Profile Plot and QC Plot uses the upper limit as rounded
 #' off maximum of log2(intensities) after normalization + 3..
 #' @param ylimDown lower limit for y-axis in the log scale. FALSE(Default) for
-#' Profile Plot and QC Plot uses 0..
+#' Profile Plot and QC Plot uses the lower limit as floor of minimum
+#' log2(intensities) after normalization - 3, or 0 if that value is negative..
 #' @param x.axis.size size of x-axis labeling for "Run" and "channel in Profile
 #' Plot and QC Plot.
 #' @param y.axis.size size of y-axis labels. Default is 10.

--- a/R/dataProcessPlotsPTM.R
+++ b/R/dataProcessPlotsPTM.R
@@ -30,7 +30,7 @@
 #' off maximum of log2(intensities) after normalization + 3..
 #' @param ylimDown lower limit for y-axis in the log scale. FALSE(Default) for
 #' Profile Plot and QC Plot uses the lower limit as floor of minimum
-#' log2(intensities) after normalization - 3, or 0 if that value is negative..
+#' log2(intensities) after normalization - 3, or 0 if that value is negative.
 #' @param x.axis.size size of x-axis labeling for "Run" and "channel in Profile
 #' Plot and QC Plot.
 #' @param y.axis.size size of y-axis labels. Default is 10.

--- a/R/utils_dataProcessPlots.R
+++ b/R/utils_dataProcessPlots.R
@@ -553,11 +553,12 @@
   if (is.numeric(ylimDown)) {
     y.limdown = ylimDown
   } else {
-    y.limdown = 0
+    all_abund = if (plot_global) c(datafeature.ptm$ABUNDANCE, datafeature.protein$ABUNDANCE) else datafeature.ptm$ABUNDANCE
+    y.limdown = max(floor(min(all_abund, na.rm = TRUE) - 3), 0)
   }
-  
+
   ## Apply pre-plot formatting
-  ptm.list = .preplot.format.tmt(datafeature.ptm, datarun.ptm, 
+  ptm.list = .preplot.format.tmt(datafeature.ptm, datarun.ptm,
                                        y.limup, type)
   datafeature.ptm = ptm.list[[1]]
   datarun.ptm = ptm.list[[2]]
@@ -871,13 +872,15 @@
     y.limup = ylimUp
   }
   
-  y.limdown = 0
   if (is.numeric(ylimDown)) {
     y.limdown = ylimDown
+  } else {
+    all_abund = if (length(data.table.list) == 4) c(datafeature.ptm$ABUNDANCE, datafeature.protein$ABUNDANCE) else datafeature.ptm$ABUNDANCE
+    y.limdown = max(floor(min(all_abund, na.rm = TRUE) - 3), 0)
   }
-  
+
   ## Apply pre-plot formatting
-  ptm.list = .preplot.format.tmt(datafeature.ptm, datarun.ptm, y.limup, 
+  ptm.list = .preplot.format.tmt(datafeature.ptm, datarun.ptm, y.limup,
                                        type)
   datafeature.ptm = ptm.list[[1]]
   datarun.ptm = ptm.list[[2]]
@@ -1374,10 +1377,11 @@
   if (is.numeric(ylimDown)) {
     y.limdown = ylimDown
   } else {
-    y.limdown = 0
+    all_abund = if (plot_global) c(datafeature.ptm$ABUNDANCE, datafeature.protein$ABUNDANCE) else datafeature.ptm$ABUNDANCE
+    y.limdown = max(floor(min(all_abund, na.rm = TRUE) - 3), 0)
   }
-  
-  ptm.list = .preplot.format.lf(datafeature.ptm, datarun.ptm, 
+
+  ptm.list = .preplot.format.lf(datafeature.ptm, datarun.ptm,
                                   y.limup, type)
   datafeature.ptm = ptm.list[[1]]
   datarun.ptm = ptm.list[[2]]
@@ -1667,11 +1671,13 @@
     y.limup = ylimUp
   }
   
-  y.limdown = 0
   if (is.numeric(ylimDown)) {
     y.limdown = ylimDown
+  } else {
+    all_abund = if (length(data.table.list) == 4) c(datafeature.ptm$ABUNDANCE, datafeature.protein$ABUNDANCE) else datafeature.ptm$ABUNDANCE
+    y.limdown = max(floor(min(all_abund, na.rm = TRUE) - 3), 0)
   }
-  
+
   ## Apply pre-plot formatting
   ptm.list = .preplot.format.lf(datafeature.ptm, datarun.ptm, y.limup, type)
   datafeature.ptm = ptm.list[[1]]

--- a/man/MSstatsPTM.Rd
+++ b/man/MSstatsPTM.Rd
@@ -56,6 +56,7 @@ analysis and summarization
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://vitek-lab.github.io/MSstatsPTM/}
   \item Report bugs at \url{https://github.com/Vitek-Lab/MSstatsPTM/issues}
 }
 

--- a/man/dataProcessPlotsPTM.Rd
+++ b/man/dataProcessPlotsPTM.Rd
@@ -43,7 +43,8 @@ FALSE(Default) for Profile Plot and QC Plot uses the upper limit as rounded
 off maximum of log2(intensities) after normalization + 3..}
 
 \item{ylimDown}{lower limit for y-axis in the log scale. FALSE(Default) for
-Profile Plot and QC Plot uses 0..}
+Profile Plot and QC Plot uses the lower limit as floor of minimum
+log2(intensities) after normalization - 3, or 0 if that value is negative..}
 
 \item{x.axis.size}{size of x-axis labeling for "Run" and "channel in Profile
 Plot and QC Plot.}

--- a/man/dataProcessPlotsPTM.Rd
+++ b/man/dataProcessPlotsPTM.Rd
@@ -44,7 +44,7 @@ off maximum of log2(intensities) after normalization + 3..}
 
 \item{ylimDown}{lower limit for y-axis in the log scale. FALSE(Default) for
 Profile Plot and QC Plot uses the lower limit as floor of minimum
-log2(intensities) after normalization - 3, or 0 if that value is negative..}
+log2(intensities) after normalization - 3, or 0 if that value is negative.}
 
 \item{x.axis.size}{size of x-axis labeling for "Run" and "channel in Profile
 Plot and QC Plot.}


### PR DESCRIPTION
## Motivation and Context

This PR modifies the default behavior for the `ylimDown` parameter in the `dataProcessPlotsPTM` function, which controls the lower y-axis limit for Profile and QC plots. Previously, when `ylimDown` was not explicitly specified (default `FALSE`), plots automatically used a lower limit of 0. This change implements a data-driven lower limit calculation that adapts to the actual intensity ranges in the dataset, specifically using the minimum log2-transformed abundance value (log2 intensity) minus 3, floored and clamped at 0 to prevent negative axis limits.

## Changes Made

- **Documentation Updates** (`R/dataProcessPlotsPTM.R` and generated `man/dataProcessPlotsPTM.Rd`):
  - Updated the `ylimDown` parameter documentation to describe the new default behavior: "floor of minimum log2(intensities) after normalization - 3, or 0 if that value is negative"

- **Core Logic Implementation** (`R/utils_dataProcessPlots.R`):
  - Modified four internal plotting functions (`.profile.tmt`, `.qc.tmt`, `.profile.lf`, `.qc.lf`) to compute `y.limdown` dynamically when `ylimDown` is not provided as a numeric value
  - When `ylimDown = FALSE` (default), the new calculation is: `y.limdown = max(floor(min(all_abund, na.rm = TRUE) - 3), 0)`
  - The `all_abund` vector includes both PTM and protein abundances when protein/global data is present, otherwise only PTM abundances
  - When `ylimDown` is explicitly provided as a numeric value, the behavior remains unchanged (uses the provided value)

- **Package Documentation** (`man/MSstatsPTM.Rd`):
  - Added a new "Useful links" entry pointing to the project website (`https://vitek-lab.github.io/MSstatsPTM/`)

- **Minor Punctuation Fix**: One commit addresses a minor punctuation issue

## Unit Tests

No new unit tests were added or modified to verify these changes. The existing test suite (`inst/tinytest/`) contains tests for data summarization, conversion utilities, and parameter validation checks, but does not include tests for the plotting functionality (`dataProcessPlotsPTM`, ProfilePlot, or QCPlot).

## Coding Guidelines Violations

Minor inconsistencies in code style:

- **Ternary-style if expressions**: The code uses `all_abund = if (condition) value1 else value2` syntax, which is unconventional for R style (more common in functional programming languages). This pattern is applied consistently across all four modified functions but may not align with traditional R coding guidelines that typically prefer explicit conditional statements.

- **Inconsistent protocol detection**: Different functions use different methods to detect whether protein data is present: some use `plot_global` variable while others use `length(data.table.list) == 4`. Both approaches are functionally equivalent but represent inconsistent code patterns within the same file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->